### PR TITLE
Change StyleEmphasize rule to ignore headers that are fully colored

### DIFF
--- a/src/Rule/CssTextStyleEmphasize.php
+++ b/src/Rule/CssTextStyleEmphasize.php
@@ -181,7 +181,7 @@ class CssTextStyleEmphasize extends BaseRule
 		$default_background = $options['backgroundColor'];
 		$default_color = $options['textColor'];
 
-		foreach ($entries as $element) { 
+		foreach ($entries as $element) {
 			if ($element->nodeType !== XML_ELEMENT_NODE) {
 				continue;
 			}
@@ -276,7 +276,9 @@ class CssTextStyleEmphasize extends BaseRule
 					$style['font-style'] = "normal";
 				}
 
-				if ($element->tagName === 'h1' || $element->tagName === 'h2' || $element->tagName === 'h3' || $element->tagName === 'h4' || $element->tagName === 'h5' || $element->tagName === 'h6' || $font_size >= 18 || $font_size >= 14 && $bold) {
+				if ($element->tagName === 'h1' || $element->tagName === 'h2' || $element->tagName === 'h3' || $element->tagName === 'h4' || $element->tagName === 'h5' || $element->tagName === 'h6' || $this->checkTextEqualsHeadingText($element)) {
+					continue;
+				} elseif ($font_size >= 18 || $font_size >= 14 && $bold) {
 					if ($luminosity >= 3 && !$bold && !$italic) {
 						$this->message["backgroundColor"] = $background;
 						$this->message["color"] = $style["color"];
@@ -300,6 +302,33 @@ class CssTextStyleEmphasize extends BaseRule
 	}
 
 	// Helpers
+
+	/**
+	 * Returns true if the tag descends from a heading tag and
+	 * contains the same text, or false otherwise.
+	 * @param object $element A DOMElement object
+	 */
+	function checkTextEqualsHeadingText($element)
+	{
+		$headingAncestor = false;
+		// Stop when we reach a heading or fail to find one.
+		for ($i = 1; $i <= 6 && !$headingAncestor; $i++) {
+			$heading = "h".$i;
+			$headingAncestor = $this->getElementAncestor($element, $heading);
+		}
+
+		// The current element is not descended from a heading.
+		if (!$headingAncestor) {
+			return false;
+		}
+
+		if ($element->textContent === $headingAncestor->textContent) {
+			return true;
+		}
+
+		return false;
+	}
+
 
 	/**
 	 *	Returns the first ancestor reached of a tag, or false if it hits

--- a/tests/CssTextStyleEmphasizeTest.php
+++ b/tests/CssTextStyleEmphasizeTest.php
@@ -12,7 +12,7 @@ class CssTextStyleEmphasizeTest extends PhpAllyTestCase {
             'backgroundColor' => '#ffffff',
             'textColor' => '#2D3B45'
         ];
-        
+
         $rule = new CssTextStyleEmphasize($dom, $options);
 
         $this->assertEquals(0, $rule->check(), 'Css Text Style Emphasize should have no issues.');
@@ -27,13 +27,13 @@ class CssTextStyleEmphasizeTest extends PhpAllyTestCase {
             'backgroundColor' => '#ffffff',
             'textColor' => '#2D3B45'
         ];
-        
+
         $rule = new CssTextStyleEmphasize($dom, $options);
 
         $this->assertEquals(1, $rule->check(), 'Css Text Style Emphasize should have two issues.');
     }
 
-    public function testCheckBackgroundAttributeColorNamePass() 
+    public function testCheckBackgroundAttributeColorNamePass()
     {
         $html = $this->getGoodBackgroundContrastColorNameHtml();
         $dom = new \DOMDocument('1.0', 'utf-8');
@@ -42,9 +42,55 @@ class CssTextStyleEmphasizeTest extends PhpAllyTestCase {
             'backgroundColor' => '#ffffff',
             'textColor' => '#2D3B45'
         ];
-        
+
         $rule = new CssTextStyleEmphasize($dom, $options);
 
-        $this->assertEquals(0, $rule->check(), 'CSS Text Has Contrast should have no issues.');
+        $this->assertEquals(0, $rule->check(), 'CSS Text Style Emphasize should have no issues.');
     }
+
+    public function testCompletelyColoredHeader()
+    {
+        $html = '<h2><span style="color: #008000;">This is a heading with color applied</span></h2>';
+        $dom = new \DOMDocument('1.0', 'utf-8');
+        $dom->loadHTML($html);
+        $options = [
+            'backgroundColor' => '#ffffff',
+            'textColor' => '#2D3B45'
+        ];
+
+        $rule = new CssTextStyleEmphasize($dom, $options);
+
+        $this->assertEquals(0, $rule->check(), 'CSS Text Style Emphasize should have no issues.');
+    }
+
+    public function testPartiallyColoredHeader()
+    {
+        $html = '<h2>This is a <span style="color: #008000;">heading</span> with only some color applied</h2>';
+        $dom = new \DOMDocument('1.0', 'utf-8');
+        $dom->loadHTML($html);
+        $options = [
+            'backgroundColor' => '#ffffff',
+            'textColor' => '#2D3B45'
+        ];
+
+        $rule = new CssTextStyleEmphasize($dom, $options);
+
+        $this->assertEquals(1, $rule->check(), 'CSS Text Style Emphasize should have one issue.');
+    }
+
+    public function testNestedDifferentColorInHeader()
+    {
+        $html = '<h2><span style="color: #008000;">This is a heading with <span style="color: #3366ff;">two colors</span> applied</span></h2>';
+        $dom = new \DOMDocument('1.0', 'utf-8');
+        $dom->loadHTML($html);
+        $options = [
+            'backgroundColor' => '#ffffff',
+            'textColor' => '#2D3B45'
+        ];
+
+        $rule = new CssTextStyleEmphasize($dom, $options);
+
+        $this->assertEquals(1, $rule->check(), 'CSS Text Style Emphasize should have one issue.');
+    }
+
 }


### PR DESCRIPTION
Changes the CssTextStyleEmphasis to allow entire headings to be colored, as the heading itself provides emphasis, and therefore is not just relying on the color for emphasis. Note that if only a subsection of the heading has a color applied it is still considered a violation of the rule.