### PR TITLE
added check for bold/em on child elements

### DIFF
--- a/src/Rule/CssTextStyleEmphasize.php
+++ b/src/Rule/CssTextStyleEmphasize.php
@@ -276,7 +276,8 @@ class CssTextStyleEmphasize extends BaseRule
 					$style['font-style'] = "normal";
 				}
 
-				if ($element->tagName === 'h1' || $element->tagName === 'h2' || $element->tagName === 'h3' || $element->tagName === 'h4' || $element->tagName === 'h5' || $element->tagName === 'h6' || $this->checkTextEqualsHeadingText($element)) {
+				if ($element->tagName === 'h1' || $element->tagName === 'h2' || $element->tagName === 'h3' || $element->tagName === 'h4' || $element->tagName === 'h5' || $element->tagName === 'h6' || $this->checkTextEqualsHeadingText($element)
+				|| $this->getElementChild($element, 'strong') || $this->getElementChild($element, 'em')) {
 					continue;
 				} elseif ($font_size >= 18 || $font_size >= 14 && $bold) {
 					if ($luminosity >= 3 && !$bold && !$italic) {
@@ -348,6 +349,19 @@ class CssTextStyleEmphasize extends BaseRule
 			}
 			$element = $element->parentNode;
 		}
+		return false;
+	}
+
+	function getElementChild($element, $ancestor_tag)
+	{
+		foreach ($element->childNodes as $child){
+			if(property_exists($child, 'tagName')){
+				if($child->tagName === $ancestor_tag){
+					return true;
+				}
+			}
+		}
+
 		return false;
 	}
 

--- a/tests/CssTextStyleEmphasizeTest.php
+++ b/tests/CssTextStyleEmphasizeTest.php
@@ -18,6 +18,21 @@ class CssTextStyleEmphasizeTest extends PhpAllyTestCase {
         $this->assertEquals(0, $rule->check(), 'Css Text Style Emphasize should have no issues.');
     }
 
+    public function testCheckTrueChildTag()
+    {
+        $html = $this->getEphasisPass();
+        $dom = new \DOMDocument('1.0', 'utf-8');
+        $dom->loadHTML($html);
+        $options = [
+            'backgroundColor' => '#ffffff',
+            'textColor' => '#2D3B45'
+        ];
+
+        $rule = new CssTextStyleEmphasize($dom, $options);
+
+        $this->assertEquals(0, $rule->check(), 'Css Text Style Emphasize should have no issues.');
+    }
+
     public function testCheckFalse()
     {
         $html = $this->getColorContrastHtml();

--- a/tests/PhpAllyTestCase.php
+++ b/tests/PhpAllyTestCase.php
@@ -44,6 +44,11 @@ class PhpAllyTestCase extends TestCase {
         </div>';
     }
 
+    protected function getEphasisPass()
+    {
+        return '<p style="color: #008000; background-color: #ffffff;"><em><strong>Testing</strong></em></p>';
+    }
+
     protected function getColorContrastHtml()
     {
         return '<div style="background-color: #444; background: no-repeat fixed center;"><p style="color: #000";">Paragraph text does not have enough contrast.</p><p style="color: #FFF";">Paragraph text does have enough contrast.</p><p style="color: #00A";">Paragraph text has blue text, no contrast.</p></div>';


### PR DESCRIPTION
- CssTextStyleEmphasize now checks the children of the element for bold and em tags, to work in conjunction with the UFIXIT form 