### PR TITLE
Simplifying "use color for emphasis" rule to ignore color contrast and focus on emphasis

### DIFF
--- a/src/Rule/BaseRule.php
+++ b/src/Rule/BaseRule.php
@@ -158,7 +158,7 @@ class BaseRule implements PhpAllyRuleInterface {
 	*	 			 to that element (ignoring inheritance)
 	*
 	*/
-	private function getNodeStyle($element) {
+	public function getNodeStyle($element) {
 		$style = array();
 
 		if($element->hasAttribute('quail_style_index')) {

--- a/src/Rule/CssTextStyleEmphasize.php
+++ b/src/Rule/CssTextStyleEmphasize.php
@@ -2,164 +2,38 @@
 
 namespace CidiLabs\PhpAlly\Rule;
 
-use DOMElement;
-use DOMXPath;
-
 /**
- *	Checks that all color and background elements are also bold or italicized
+ *	Checks that all colored background elements are also bold or italicized
  */
 class CssTextStyleEmphasize extends BaseRule
 {
-	public $color_names = array(
-		'aliceblue' => 'f0f8ff',
-		'antiquewhite' => 'faebd7',
-		'aqua' => '00ffff',
-		'aquamarine' => '7fffd4',
-		'azure' => 'f0ffff',
-		'beige' => 'f5f5dc',
-		'bisque' => 'ffe4c4',
-		'black' => '000000',
-		'blanchedalmond' => 'ffebcd',
-		'blue' => '0000ff',
-		'blueviolet' => '8a2be2',
-		'brown' => 'a52a2a',
-		'burlywood' => 'deb887',
-		'cadetblue' => '5f9ea0',
-		'chartreuse' => '7fff00',
-		'chocolate' => 'd2691e',
-		'coral' => 'ff7f50',
-		'cornflowerblue' => '6495ed',
-		'cornsilk' => 'fff8dc',
-		'crimson' => 'dc143c',
-		'cyan' => '00ffff',
-		'darkblue' => '00008b',
-		'darkcyan' => '008b8b',
-		'darkgoldenrod' => 'b8860b',
-		'darkgray' => 'a9a9a9',
-		'darkgreen' => '006400',
-		'darkkhaki' => 'bdb76b',
-		'darkmagenta' => '8b008b',
-		'darkolivegreen' => '556b2f',
-		'darkorange' => 'ff8c00',
-		'darkorchid' => '9932cc',
-		'darkred' => '8b0000',
-		'darksalmon' => 'e9967a',
-		'darkseagreen' => '8fbc8f',
-		'darkslateblue' => '483d8b',
-		'darkslategray' => '2f4f4f',
-		'darkturquoise' => '00ced1',
-		'darkviolet' => '9400d3',
-		'deeppink' => 'ff1493',
-		'deepskyblue' => '00bfff',
-		'dimgray' => '696969',
-		'dodgerblue' => '1e90ff',
-		'firebrick' => 'b22222',
-		'floralwhite' => 'fffaf0',
-		'forestgreen' => '228b22',
-		'fuchsia' => 'ff00ff',
-		'gainsboro' => 'dcdcdc',
-		'ghostwhite' => 'f8f8ff',
-		'gold' => 'ffd700',
-		'goldenrod' => 'daa520',
-		'gray' => '808080',
-		'green' => '008000',
-		'greenyellow' => 'adff2f',
-		'grey' => '808080',
-		'honeydew' => 'f0fff0',
-		'hotpink' => 'ff69b4',
-		'indianred' => 'cd5c5c',
-		'indigo' => '4b0082',
-		'ivory' => 'fffff0',
-		'khaki' => 'f0e68c',
-		'lavender' => 'e6e6fa',
-		'lavenderblush' => 'fff0f5',
-		'lawngreen' => '7cfc00',
-		'lemonchiffon' => 'fffacd',
-		'lightblue' => 'add8e6',
-		'lightcoral' => 'f08080',
-		'lightcyan' => 'e0ffff',
-		'lightgoldenrodyellow' => 'fafad2',
-		'lightgrey' => 'd3d3d3',
-		'lightgreen' => '90ee90',
-		'lightpink' => 'ffb6c1',
-		'lightsalmon' => 'ffa07a',
-		'lightseagreen' => '20b2aa',
-		'lightskyblue' => '87cefa',
-		'lightslategray' => '778899',
-		'lightsteelblue' => 'b0c4de',
-		'lightyellow' => 'ffffe0',
-		'lime' => '00ff00',
-		'limegreen' => '32cd32',
-		'linen' => 'faf0e6',
-		'magenta' => 'ff00ff',
-		'maroon' => '800000',
-		'mediumaquamarine' => '66cdaa',
-		'mediumblue' => '0000cd',
-		'mediumorchid' => 'ba55d3',
-		'mediumpurple' => '9370d8',
-		'mediumseagreen' => '3cb371',
-		'mediumslateblue' => '7b68ee',
-		'mediumspringgreen' => '00fa9a',
-		'mediumturquoise' => '48d1cc',
-		'mediumvioletred' => 'c71585',
-		'midnightblue' => '191970',
-		'mintcream' => 'f5fffa',
-		'mistyrose' => 'ffe4e1',
-		'moccasin' => 'ffe4b5',
-		'navajowhite' => 'ffdead',
-		'navy' => '000080',
-		'oldlace' => 'fdf5e6',
-		'olive' => '808000',
-		'olivedrab' => '6b8e23',
-		'orange' => 'ffa500',
-		'orangered' => 'ff4500',
-		'orchid' => 'da70d6',
-		'palegoldenrod' => 'eee8aa',
-		'palegreen' => '98fb98',
-		'paleturquoise' => 'afeeee',
-		'palevioletred' => 'd87093',
-		'papayawhip' => 'ffefd5',
-		'peachpuff' => 'ffdab9',
-		'peru' => 'cd853f',
-		'pink' => 'ffc0cb',
-		'plum' => 'dda0dd',
-		'powderblue' => 'b0e0e6',
-		'purple' => '800080',
-		'red' => 'ff0000',
-		'rosybrown' => 'bc8f8f',
-		'royalblue' => '4169e1',
-		'saddlebrown' => '8b4513',
-		'salmon' => 'fa8072',
-		'sandybrown' => 'f4a460',
-		'seagreen' => '2e8b57',
-		'seashell' => 'fff5ee',
-		'sienna' => 'a0522d',
-		'silver' => 'c0c0c0',
-		'skyblue' => '87ceeb',
-		'slateblue' => '6a5acd',
-		'slategray' => '708090',
-		'snow' => 'fffafa',
-		'springgreen' => '00ff7f',
-		'steelblue' => '4682b4',
-		'tan' => 'd2b48c',
-		'teal' => '008080',
-		'thistle' => 'd8bfd8',
-		'tomato' => 'ff6347',
-		'turquoise' => '40e0d0',
-		'violet' => 'ee82ee',
-		'wheat' => 'f5deb3',
-		'white' => 'ffffff',
-		'whitesmoke' => 'f5f5f5',
-		'yellow' => 'ffff00',
-		'yellowgreen' => '9acd32'
-		);
+	public static $blockElements = [
+		'p', 
+		'td', 
+		'div', 
+		'li',
+		'h1',
+		'h2',
+		'h3',
+		'h4',
+		'h5',
+		'h6',
+	];
 
-	public $message = array(
-		'backgroundColor' => '',
-		'color' => '',
-		'fontStyle' => '',
-		'fontWeight' => '',
-	);
+	public static $genericTextElements = [
+		'span',
+		'font',
+	];
+
+	public static $emphasizedTextElements = [
+		'b',
+		'strong',
+		'em',
+		'small',
+		'sup',
+		'sub',
+		'a',
+	];
 
 	public function id()
 	{
@@ -168,387 +42,55 @@ class CssTextStyleEmphasize extends BaseRule
 
 	public function check()
 	{
-		$xpath   = new DOMXPath($this->dom);
 		/**
-		 * Selects all nodes that have a style attribute OR 'strong' OR 'em' elements that:
-		 * Contain only the text in their text nodes
-		 * OR 	 Have text nodes AND text nodes that are not equal to the string-value of the context node
-		 * OR 	 Have a text node descendant that equals the string-value of the context node and has no style attributes
+		 * Select all generic text elements.
+		 * Check if they have a style attribute.
+		 * Check if style attribute applies a color or background-color.
+		 * 
+		 * We aren't doing any checks on color contrast here. 
 		 */
-		$entries = $xpath->query('//*[(text() = . or ( ./*[text() != .]) or (.//*[text() = . and not(@style)])) and ((@style) or (name() = "strong") or (name() = "em"))]');
 
-		$options = $this->getOptions();
-		$default_background = $options['backgroundColor'];
-		$default_color = $options['textColor'];
+		foreach ($this->getAllElements(self::$genericTextElements) as $element) {
+			$styles = $this->getNodeStyle($element);
+			$elementText = trim($element->textContent);
 
-		foreach ($entries as $element) {
-			if ($element->nodeType !== XML_ELEMENT_NODE) {
+			if (!isset($styles['background-color']) && !isset($styles['color'])) {
+				continue;
+			}
+			if (isset($styles['font-weight']) || isset($styles['font-style'])) {
 				continue;
 			}
 
-			$style = $this->getStyle($element);
+			// skip if parent text == element text AND parent element is emphasized
+			$parentNode = $element->parentNode;
+			if ($parentNode && ($parentNode->nodeType === XML_ELEMENT_NODE)) {
+				$parentText = trim($parentNode->textContent);
 
-			if(isset($style['background'])) {
-				$background = $this->getBackgroundInfo($style['background']);
-
-				if($background) {
-					$style["background-color"] = $background;
-				}
-			}
-
-			if (!isset($style['background-color'])) {
-				$style['background-color'] = $default_background;
-			}
-
-			if ((isset($style['background']) || isset($style['background-color'])) && isset($style['color']) && $element->nodeValue) {
-				$background = (isset($style['background-color'])) ? $style['background-color'] : $style['background'];
-
-				if (!$background) {
-					$background = $default_background;
-				}
-
-				if(strtolower(substr($style['color'], 0, 3)) == 'rgb') {
-					// Explode the match (0,0,0 for example) into an array
-					$style['color'] = substr($style['color'], 4, -1);
-					$colors = explode(',', $style['color']);
-					// Use sprintf for the conversion
-					$style['color'] = sprintf("#%02x%02x%02x", $colors[0], $colors[1], $colors[2]);
-				} else {
-					$style['color'] = '#' . $this->convertColor($style['color']);
-				}
-
-				if(strtolower(substr($background, 0, 3)) == 'rgb') {
-					// Explode the match (0,0,0 for example) into an array
-					$background = substr($background, 4, -1);
-					$colors = explode(',', $background);
-					// Use sprintf for the conversion
-					$background = sprintf("#%02x%02x%02x", $colors[0], $colors[1], $colors[2]);
-				} else {
-					$background = '#' . $this->convertColor($background);
-				}
-
-				$luminosity = $this->getLuminosity($style['color'], $background);
-				$font_size = 0;
-				$bold = false;
-				$italic = false;
-
-				if (isset($style['font-size'])) {
-					preg_match_all('!\d+!', $style['font-size'], $matches);
-					$font_size = $matches[0][0];
-				}
-
-				if (isset($style['font-weight'])) {
-					preg_match_all('!\d+!', $style['font-weight'], $matches);
-
-					if (count($matches) > 0) {
-						if ($matches >= 700) {
-							$bold = true;
-						} else {
-							if ($style['font-weight'] === 'bold' || $style['font-weight'] === 'bolder') {
-								$bold = true;
-							}
-						}
+				if ($parentText == $elementText) {
+					if (in_array($parentNode->tagName, self::$emphasizedTextElements)) {
+						continue;
 					}
-				} else if (
-					$element->tagName === "strong"
-					|| $this->getElementAncestor($element, 'strong')
-					|| (isset($element->nodeValue)
-						&& isset($element->firstChild->nodeValue)
-						&& $element->nodeValue == $element->firstChild->nodeValue
-						&& is_object($element->firstChild)
-						&& property_exists($element->firstChild, 'tagName')
-						&& $element->firstChild->tagName === 'strong')
-				) {
-					$bold = true;
-					$style['font-weight'] = "bold";
-				} else {
-					$style['font-weight'] = "normal";
-				}
-
-				if (isset($style['font-style'])) {
-					if ($style['font-style'] === "italic") {
-						$italic = true;
-					}
-				} else if ($element->tagName === "em") {
-					$italic = true;
-					$style['font-style'] = "italic";
-				} else {
-					$style['font-style'] = "normal";
-				}
-
-				if ($this->isHeading($element) || $this->checkTextEqualsHeadingText($element) || $this->getElementChild($element, 'strong') || $this->getElementChild($element, 'em')) {
-					continue;
-				} elseif ($font_size >= 18 || $font_size >= 14 && $bold) {
-					if ($luminosity >= 3 && !$bold && !$italic) {
-						$this->message["backgroundColor"] = $background;
-						$this->message["color"] = $style["color"];
-						$this->message["fontStyle"] = $style["font-style"];
-						$this->message["fontWeight"] = $style["font-weight"];
-						$this->setIssue($element, null, json_encode($this->message));
-					}
-				} else {
-					if ($luminosity >= 4.5 && !$bold && !$italic) {
-						$this->message["backgroundColor"] = $background;
-						$this->message["color"] = $style["color"];
-						$this->message["fontStyle"] = $style["font-style"];
-						$this->message["fontWeight"] = $style["font-weight"];
-						$this->setIssue($element, null, json_encode($this->message));
+					if (in_array($parentNode->tagName, self::$blockElements)) {
+						continue;
 					}
 				}
 			}
+			
+			// skip if child text == element text AND child is emphasized
+			$childNode = (isset($element->nodeValue) && isset($element->firstChild->nodeValue)) ? $element->firstChild : null;
+			if ($childNode && $childNode->nodeType === XML_ELEMENT_NODE) {
+				$childText = trim($childNode->textContent);
+
+				if ($childText == $elementText) {
+					if (in_array($childNode->tagName, self::$emphasizedTextElements)) {
+						continue;
+					}
+				}
+			}
+
+			$this->setIssue($element);
 		}
 
 		return count($this->issues);
 	}
-
-	// Helpers
-
-	/**
-	 * Returns true the element is a heading 
-	 * @param object $element A DOMElement object
-	 */
-	function isHeading($element) {
-		if (property_exists($element, 'tagName')) {
-			if ($element->tagName === 'h1' || $element->tagName === 'h2' || $element->tagName === 'h3' 
-			|| $element->tagName === 'h4' || $element->tagName === 'h5' || $element->tagName === 'h6') {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Returns true if the tag descends from a heading tag and
-	 * contains the same text, or false otherwise.
-	 * @param object $element A DOMElement object
-	 */
-	function checkTextEqualsHeadingText($element)
-	{
-		$headingAncestor = false;
-		// Stop when we reach a heading or fail to find one.
-		for ($i = 1; $i <= 6 && !$headingAncestor; $i++) {
-			$heading = "h".$i;
-			$headingAncestor = $this->getElementAncestor($element, $heading);
-		}
-
-		// The current element is not descended from a heading.
-		if (!$headingAncestor) {
-			return false;
-		}
-
-		if ($element->textContent === $headingAncestor->textContent) {
-			return true;
-		}
-
-		return false;
-	}
-
-
-	/**
-	 *	Returns the first ancestor reached of a tag, or false if it hits
-	 *	the document root or a given tag.
-	 *	@param object $element A DOMElement object
-	 *	@param string $ancestor_tag The name of the tag we are looking for
-	 *	@param string $limit_tag Where to stop searching
-	 */
-	function getElementAncestor($element, $ancestor_tag, $limit_tag = 'body')
-	{
-		while (property_exists($element->parentNode, 'tagName')) {
-			if ($element->parentNode->tagName == $ancestor_tag) {
-				return $element->parentNode;
-			}
-			if ($element->parentNode->tagName == $limit_tag) {
-				return false;
-			}
-			$element = $element->parentNode;
-		}
-		return false;
-	}
-
-	/**
-	 *	Returns true if an immediate child of the element is a given tag
-	 *	@param object $element A DOMElement object
-	 *	@param string $child_tag The name of the tag we are looking for
-	 */
-	function getElementChild($element, $child_tag)
-	{
-		foreach ($element->childNodes as $child){
-			if(property_exists($child, 'tagName')){
-				if($child->tagName === $child_tag){
-					return true;
-				}
-			}
-		}
-
-		return false;
-	}
-
-	// CSS Helpers
-
-	public function parseCSS($css)
-	{
-		$results = array();
-		preg_match_all("/([\w-]+)\s*:\s*([^;]+)\s*;?/", $css, $matches, PREG_SET_ORDER);
-		foreach ($matches as $match) {
-			$results[$match[1]] = $match[2];
-		}
-
-		return $results;
-	}
-
-	/**
-	 *	Converts multiple color or background styles into a simple hex string
-	 *	@param string $color The color attribute to convert (this can also be a multi-value css background value)
-	 *	@return string A standard CSS hex value for the color
-	 */
-	public function convertColor($color)
-	{
-		$color = trim($color);
-		if (strpos($color, ' ') !== false) {
-			$colors = explode(' ', $color);
-			foreach ($colors as $background_part) {
-				if (
-					substr(trim($background_part), 0, 1) == '#' ||
-					in_array(trim($background_part), array_keys($this->color_names)) ||
-					strtolower(substr(trim($background_part), 0, 3)) == 'rgb'
-				) {
-					$color = $background_part;
-				}
-			}
-		}
-		//Normal hex color
-		if (substr($color, 0, 1) == '#') {
-			if (strlen($color) == 7) {
-				return str_replace('#', '', $color);
-			} elseif (strlen($color) == 4) {
-				return substr($color, 1, 1) . substr($color, 1, 1) .
-					substr($color, 2, 1) . substr($color, 2, 1) .
-					substr($color, 3, 1) . substr($color, 3, 1);
-			} else {
-				return "000000";
-			}
-		}
-		//Named Color
-		if (in_array($color, array_keys($this->color_names))) {
-			return $this->color_names[$color];
-		}
-		//rgb values
-		if (strtolower(substr($color, 0, 3)) == 'rgb') {
-			$colors = explode(',', trim(str_replace('rgb(', '', $color), '()'));
-			if (!count($colors) != 3) {
-				return false;
-			}
-			$r = intval($colors[0]);
-			$g = intval($colors[1]);
-			$b = intval($colors[2]);
-
-			$r = dechex($r < 0 ? 0 : ($r > 255 ? 255 : $r));
-			$g = dechex($g < 0 ? 0 : ($g > 255 ? 255 : $g));
-			$b = dechex($b < 0 ? 0 : ($b > 255 ? 255 : $b));
-
-			$color = (strlen($r) < 2 ? '0' : '') . $r;
-			$color .= (strlen($g) < 2 ? '0' : '') . $g;
-			$color .= (strlen($b) < 2 ? '0' : '') . $b;
-			return $color;
-		}
-	}
-
-	/**
-	 *	Helper method that finds the luminosity between the provided
-	 *	foreground and background parameters.
-	 *	@param string $foreground The HEX value of the foreground color
-	 *	@param string $background The HEX value of the background color
-	 *	@return float The luminosity contrast ratio between the colors
-	 */
-	public function getLuminosity($foreground, $background)
-	{
-		if ($foreground == $background) return 0;
-		$fore_rgb = $this->getRGB($foreground);
-		$back_rgb = $this->getRGB($background);
-		return $this->luminosity(
-			$fore_rgb['r'],
-			$back_rgb['r'],
-			$fore_rgb['g'],
-			$back_rgb['g'],
-			$fore_rgb['b'],
-			$back_rgb['b']
-		);
-	}
-
-	/**
-	 *	Returns the luminosity between two colors
-	 *	@param string $r The first Red value
-	 *	@param string $r2 The second Red value
-	 *	@param string $g The first Green value
-	 *	@param string $g2 The second Green value
-	 *	@param string $b The first Blue value
-	 *	@param string $b2 The second Blue value
-	 *	@return float The luminosity contrast ratio between the colors
-	 */
-	public function luminosity($r, $r2, $g, $g2, $b, $b2)
-	{
-		$RsRGB = $r / 255;
-		$GsRGB = $g / 255;
-		$BsRGB = $b / 255;
-		$R = ($RsRGB <= 0.03928) ? $RsRGB / 12.92 : pow(($RsRGB + 0.055) / 1.055, 2.4);
-		$G = ($GsRGB <= 0.03928) ? $GsRGB / 12.92 : pow(($GsRGB + 0.055) / 1.055, 2.4);
-		$B = ($BsRGB <= 0.03928) ? $BsRGB / 12.92 : pow(($BsRGB + 0.055) / 1.055, 2.4);
-
-		$RsRGB2 = $r2 / 255;
-		$GsRGB2 = $g2 / 255;
-		$BsRGB2 = $b2 / 255;
-		$R2 = ($RsRGB2 <= 0.03928) ? $RsRGB2 / 12.92 : pow(($RsRGB2 + 0.055) / 1.055, 2.4);
-		$G2 = ($GsRGB2 <= 0.03928) ? $GsRGB2 / 12.92 : pow(($GsRGB2 + 0.055) / 1.055, 2.4);
-		$B2 = ($BsRGB2 <= 0.03928) ? $BsRGB2 / 12.92 : pow(($BsRGB2 + 0.055) / 1.055, 2.4);
-
-		if ($r + $g + $b <= $r2 + $g2 + $b2) {
-			$l2 = (.2126 * $R + 0.7152 * $G + 0.0722 * $B);
-			$l1 = (.2126 * $R2 + 0.7152 * $G2 + 0.0722 * $B2);
-		} else {
-			$l1 = (.2126 * $R + 0.7152 * $G + 0.0722 * $B);
-			$l2 = (.2126 * $R2 + 0.7152 * $G2 + 0.0722 * $B2);
-		}
-
-		$luminosity = round(($l1 + 0.05) / ($l2 + 0.05), 2);
-		return $luminosity;
-	}
-
-
-	/**
-	 *	Returns the decimal equivalents for a HEX color
-	 *	@param string $color The hex color value
-	 *	@return array An array where 'r' is the Red value, 'g' is Green, and 'b' is Blue
-	 */
-	function getRGB($color)
-	{
-		$color =  $this->convertColor($color);
-		$c = str_split($color, 2);
-		if (count($c) != 3) {
-			return false;
-		}
-		$results = array('r' => hexdec($c[0]), 'g' => hexdec($c[1]), 'b' => hexdec($c[2]));
-		return $results;
-	}
-
-	function getBackgroundInfo($backgroundString) {
-		$regex = '/(?:#|0x)(?:[a-f0-9]{3}|[a-f0-9]{6})\b|(?:rgb|hsl)a?\([^\)]*\)/';
-
-		//Check to see if string contains hex or rgb value
-		if (preg_match($regex, trim($backgroundString), $matches)) {
-			return trim($matches[0]);
-		}
-
-		//Check for color string
-		foreach(array_keys($this->color_names) as $color) {
-			if(strpos(trim($backgroundString), $color) !== FALSE) {
-				return "#" . $this->color_names[$color];
-			}
-		}
-
-		//No background color found. Return  null
-		return null;
-	}
-
-
 }

--- a/src/Rule/VideosEmbeddedOrLinkedNeedCaptions.php
+++ b/src/Rule/VideosEmbeddedOrLinkedNeedCaptions.php
@@ -46,11 +46,17 @@ class VideosEmbeddedOrLinkedNeedCaptions extends BaseRule
 		$search_kaltura = '/(kaltura)/';
 
 		if (preg_match($search_youtube, $attr_val)) {
-			$service = new Youtube(new \GuzzleHttp\Client(['http_errors' => false]), $this->lang, $this->options['youtubeApiKey']);
+			if (!empty($this->options['youtubeApiKey'])) {
+				$service = new Youtube(new \GuzzleHttp\Client(['http_errors' => false]), $this->lang, $this->options['youtubeApiKey']);
+			}
 		} elseif (preg_match($search_vimeo, $attr_val)) {
-			$service = new Vimeo(new \GuzzleHttp\Client(['http_errors' => false]), $this->lang, $this->options['vimeoApiKey']);
+			if (!empty($this->options['vimeoApiKey'])) {
+				$service = new Vimeo(new \GuzzleHttp\Client(['http_errors' => false]), $this->lang, $this->options['vimeoApiKey']);
+			}
 		} else if (preg_match($search_kaltura, $attr_val)) {
-			$service = new Kaltura($this->lang, $this->options['kalturaApiKey'], $this->options['kalturaUsername']);
+			if (!empty($this->options['kalturaApiKey'])) {
+				$service = new Kaltura($this->lang, $this->options['kalturaApiKey'], $this->options['kalturaUsername']);
+			}
 		}
 		if (isset($service)) {
 			$captionState = $service->captionsMissing($attr_val);

--- a/tests/CssTextStyleEmphasizeTest.php
+++ b/tests/CssTextStyleEmphasizeTest.php
@@ -3,109 +3,91 @@
 use CidiLabs\PhpAlly\Rule\CssTextStyleEmphasize;
 
 class CssTextStyleEmphasizeTest extends PhpAllyTestCase {
-    public function testCheckTrue()
+
+    public function testValidHtml()
     {
-        $html = $this->getGoodColorContrastHtml();
-        $dom = new \DOMDocument('1.0', 'utf-8');
-        $dom->loadHTML($html);
-        $options = [
-            'backgroundColor' => '#ffffff',
-            'textColor' => '#2D3B45'
-        ];
+        foreach ($this->getValidTestHtml() as $key => $html) {
+            foreach (CssTextStyleEmphasize::$blockElements as $blockTag) {
+                foreach (CssTextStyleEmphasize::$genericTextElements as $genericTag) {
+                    foreach (CssTextStyleEmphasize::$emphasizedTextElements as $emphasisTag) {
+                        $search = ['{block_tag}', '{generic_tag}', '{emphasis_tag}'];
+                        $replace = [$blockTag, $genericTag, $emphasisTag];
 
-        $rule = new CssTextStyleEmphasize($dom, $options);
+                        $testKey = str_replace($search, $replace, $key);
+                        $testHtml = str_replace($search, $replace, $html);
 
-        $this->assertEquals(0, $rule->check(), 'Css Text Style Emphasize should have no issues.');
+                        $dom = new \DOMDocument('1.0', 'utf-8');
+                        $dom->loadHTML($testHtml);
+                        $rule = new CssTextStyleEmphasize($dom, []);
+
+                        $this->assertEquals(0, $rule->check(), "CSS text style emphasis: {$testKey}");
+                    }
+                }
+            }
+        }
     }
 
-    public function testCheckTrueChildTag()
+    public function testInvalidHtml()
     {
-        $html = $this->getEphasisPass();
-        $dom = new \DOMDocument('1.0', 'utf-8');
-        $dom->loadHTML($html);
-        $options = [
-            'backgroundColor' => '#ffffff',
-            'textColor' => '#2D3B45'
-        ];
+        foreach ($this->getInvalidTestHtml() as $key => $html) {
+            foreach (CssTextStyleEmphasize::$blockElements as $blockTag) {
+                foreach (CssTextStyleEmphasize::$genericTextElements as $genericTag) {
+                    foreach (CssTextStyleEmphasize::$emphasizedTextElements as $emphasisTag) {
+                        $search = ['{block_tag}', '{generic_tag}', '{emphasis_tag}'];
+                        $replace = [$blockTag, $genericTag, $emphasisTag];
+                        
+                        $testKey = str_replace($search, $replace, $key);
+                        $testHtml = str_replace($search, $replace, $html);
 
-        $rule = new CssTextStyleEmphasize($dom, $options);
+                        $dom = new \DOMDocument('1.0', 'utf-8');
+                        $dom->loadHTML($testHtml);
+                        $rule = new CssTextStyleEmphasize($dom, []);
 
-        $this->assertEquals(0, $rule->check(), 'Css Text Style Emphasize should have no issues.');
+                        $this->assertEquals(1, $rule->check(), "CSS text style emphasis: {$testKey}");
+                    }
+                }
+            }
+        }
     }
 
-    public function testCheckFalse()
+    protected function getValidTestHtml()
     {
-        $html = $this->getColorContrastHtml();
-        $dom = new \DOMDocument('1.0', 'utf-8');
-        $dom->loadHTML($html);
-        $options = [
-            'backgroundColor' => '#ffffff',
-            'textColor' => '#2D3B45'
+        return [
+            // block tag outside generic, no text
+            "valid {block_tag}, colored {generic_tag}, no text" => "<{block_tag}><{generic_tag} style='color: red'>COLORED EMPHASIS</{generic_tag}></{block_tag}>",
+            "valid {block_tag}, bgcolor {generic_tag}, no text" => "<{block_tag}><{generic_tag} style='background-color: red;'>BG COLORED EMPHASIS</{generic_tag}></{block_tag}>",
+            
+            // block tag outside generic w/ font-weight
+            "valid {block_tag} > colored {generic_tag} with font-weight" => "<{block_tag}><{generic_tag} style='color: #FF0000; font-weight: bold;'>COLORED EMPHASIS</{generic_tag}>.</{block_tag}>",
+            "valid {block_tag} > bgcolor {generic_tag} with font-weight" => "<{block_tag}><{generic_tag} style='background-color: #FF0000; font-weight: bold'>BG COLORED EMPHASIS</{generic_tag}>.</{block_tag}>",
+
+            // block tag outside generic w/ font-style
+            "valid {block_tag} > colored {generic_tag} with font-style" => "<{block_tag}><{generic_tag} style='color: #F00; font-style: italic;'>COLORED EMPHASIS</{generic_tag}>.</{block_tag}>",
+            "valid {block_tag} > bgcolor {generic_tag} with font-style" => "<{block_tag}><{generic_tag} style='background-color: #F00; font-style: italic;'>BG COLORED EMPHASIS</{generic_tag}>.</{block_tag}>",
+
+            // emphasis tag outside generic
+            "valid {emphasis_tag} > colored {generic_tag}" => "<{emphasis_tag}><{generic_tag} style='color: rgb(255,0,0);'>COLORED EMPHASIS</{generic_tag}></{emphasis_tag}>",
+            "valid {emphasis_tag} > bgcolor {generic_tag}" => "<{emphasis_tag}><{generic_tag} style='background-color: rgb(255,0,0);'>BG COLORED EMPHASIS</{generic_tag}></{emphasis_tag}>",
+
+            // emphasis tag inside generic, no text
+            "valid colored {generic_tag} > {emphasis_tag}" => "<{generic_tag} style='color: rgba(255,0,0,1);'><{emphasis_tag}>COLORED EMPHASIS</{emphasis_tag}></{generic_tag}>",
+            "valid bgcolor {generic_tag} > {emphasis_tag}" => "<{generic_tag} style='background-color: rgba(255,0,0,1);'><{emphasis_tag}>BG COLORED EMPHASIS</{emphasis_tag}></{generic_tag}>",
+            
+            // emphasis tag w/ color
+            "valid colored {emphasis_tag}" => "<{block_tag}><{emphasis_tag} style='color: red'>COLORED EMPHASIS</{emphasis_tag}>.</{block_tag}>",
+            "valid bgcolor {emphasis_tag}" => "<{block_tag}><{emphasis_tag} style='background-color: red;'>BG COLORED EMPHASIS</{emphasis_tag}>.</{block_tag}>",
         ];
-
-        $rule = new CssTextStyleEmphasize($dom, $options);
-
-        $this->assertEquals(1, $rule->check(), 'Css Text Style Emphasize should have two issues.');
     }
 
-    public function testCheckBackgroundAttributeColorNamePass()
+    protected function getInvalidTestHtml()
     {
-        $html = $this->getGoodBackgroundContrastColorNameHtml();
-        $dom = new \DOMDocument('1.0', 'utf-8');
-        $dom->loadHTML($html);
-        $options = [
-            'backgroundColor' => '#ffffff',
-            'textColor' => '#2D3B45'
+        return [
+            "invalid {block_tag}, colored {generic_tag}, text before" => "<{block_tag}>Example text with <{generic_tag} style='color: red'>COLORED EMPHASIS</{generic_tag}>.</{block_tag}>",
+            "invalid {block_tag}, bgcolor {generic_tag}, text before" => "<{block_tag}>Example text with <{generic_tag} style='background-color: red;'>BG COLORED EMPHASIS</{generic_tag}>.</{block_tag}>",
+            "invalid {block_tag}, colored {generic_tag}, text both" => "<{block_tag}>Example text with <{generic_tag} style='color: red'>COLORED EMPHASIS</{generic_tag}> and text after.</{block_tag}>",
+            "invalid {block_tag{, bgcolor {generic_tag}, text both" => "<{block_tag}>Example text with <{generic_tag} style='background-color: red;'>BG COLORED EMPHASIS</{generic_tag}> and text after.</{block_tag}>",
+            "invalid {block_tag}, colored {generic_tag}, text after" => "<{block_tag}><{generic_tag} style='color: red'>COLORED EMPHASIS</{generic_tag}> with text after.</{block_tag}>",
+            "invalid {block_tag{, bgcolor {generic_tag}, text after" => "<{block_tag}><{generic_tag} style='background-color: red;'>BG COLORED EMPHASIS</{generic_tag}> with text after.</{block_tag}>",
         ];
-
-        $rule = new CssTextStyleEmphasize($dom, $options);
-
-        $this->assertEquals(0, $rule->check(), 'CSS Text Style Emphasize should have no issues.');
     }
-
-    public function testCompletelyColoredHeader()
-    {
-        $html = '<h2><span style="color: #008000;">This is a heading with color applied</span></h2>';
-        $dom = new \DOMDocument('1.0', 'utf-8');
-        $dom->loadHTML($html);
-        $options = [
-            'backgroundColor' => '#ffffff',
-            'textColor' => '#2D3B45'
-        ];
-
-        $rule = new CssTextStyleEmphasize($dom, $options);
-
-        $this->assertEquals(0, $rule->check(), 'CSS Text Style Emphasize should have no issues.');
-    }
-
-    public function testPartiallyColoredHeader()
-    {
-        $html = '<h2>This is a <span style="color: #008000;">heading</span> with only some color applied</h2>';
-        $dom = new \DOMDocument('1.0', 'utf-8');
-        $dom->loadHTML($html);
-        $options = [
-            'backgroundColor' => '#ffffff',
-            'textColor' => '#2D3B45'
-        ];
-
-        $rule = new CssTextStyleEmphasize($dom, $options);
-
-        $this->assertEquals(1, $rule->check(), 'CSS Text Style Emphasize should have one issue.');
-    }
-
-    public function testNestedDifferentColorInHeader()
-    {
-        $html = '<h2><span style="color: #008000;">This is a heading with <span style="color: #3366ff;">two colors</span> applied</span></h2>';
-        $dom = new \DOMDocument('1.0', 'utf-8');
-        $dom->loadHTML($html);
-        $options = [
-            'backgroundColor' => '#ffffff',
-            'textColor' => '#2D3B45'
-        ];
-
-        $rule = new CssTextStyleEmphasize($dom, $options);
-
-        $this->assertEquals(1, $rule->check(), 'CSS Text Style Emphasize should have one issue.');
-    }
-
 }

--- a/tests/KalturaTest.php
+++ b/tests/KalturaTest.php
@@ -13,7 +13,7 @@ class KalturaTest extends PhpAllyTestCase {
 
         $kalturaMock = $this->getMockBuilder(Kaltura::class)
              ->setConstructorArgs(['en', 'testApiKey', 'testEmail'])
-             ->addMethods(array('getVideoData'))
+             ->onlyMethods(array('getVideoData'))
              ->getMock(); 
 
         $this->assertEquals($kalturaMock->captionsMissing($link_url), 2);
@@ -34,7 +34,7 @@ class KalturaTest extends PhpAllyTestCase {
 
         $kalturaMock = $this->getMockBuilder(Kaltura::class)
             ->setConstructorArgs(['en', 'testApiKey', 'testEmail'])
-            ->addMethods(array('getVideoData'))
+            ->onlyMethods(array('getVideoData'))
             ->getMock();
 
         $kalturaMock->expects($this->once())
@@ -55,7 +55,7 @@ class KalturaTest extends PhpAllyTestCase {
 
         $kalturaMock = $this->getMockBuilder(Kaltura::class)
             ->setConstructorArgs(['en', 'testApiKey', 'testEmail'])
-            ->addMethods(array('getVideoData'))
+            ->onlyMethods(array('getVideoData'))
             ->getMock();
 
         $kalturaMock->expects($this->once())
@@ -72,7 +72,7 @@ class KalturaTest extends PhpAllyTestCase {
         
         $kalturaMock = $this->getMockBuilder(Kaltura::class)
              ->setConstructorArgs(['en', 'testApiKey', 'testEmail'])
-             ->addMethods(array('getVideoData'))
+             ->onlyMethods(array('getVideoData'))
              ->getMock(); 
 
         $this->assertEquals($kalturaMock->captionsLanguage($link_url), 2);
@@ -93,7 +93,7 @@ class KalturaTest extends PhpAllyTestCase {
 
         $kalturaMock = $this->getMockBuilder(Kaltura::class)
             ->setConstructorArgs(['en', 'testApiKey', 'testEmail'])
-            ->addMethods(array('getVideoData'))
+            ->onlyMethods(array('getVideoData'))
             ->getMock();
 
         $kalturaMock->expects($this->once())
@@ -114,7 +114,7 @@ class KalturaTest extends PhpAllyTestCase {
 
         $kalturaMock = $this->getMockBuilder(Kaltura::class)
             ->setConstructorArgs(['en', 'testApiKey', 'testEmail'])
-            ->addMethods(array('getVideoData'))
+            ->onlyMethods(array('getVideoData'))
             ->getMock();
 
         $kalturaMock->expects($this->once())
@@ -139,7 +139,7 @@ class KalturaTest extends PhpAllyTestCase {
 
         $kalturaMock = $this->getMockBuilder(Kaltura::class)
             ->setConstructorArgs(['en', 'testApiKey', 'testEmail'])
-            ->addMethods(array('getVideoData'))
+            ->onlyMethods(array('getVideoData'))
             ->getMock();
 
         $kalturaMock->expects($this->once())
@@ -164,7 +164,7 @@ class KalturaTest extends PhpAllyTestCase {
 
         $kalturaMock = $this->getMockBuilder(Kaltura::class)
             ->setConstructorArgs(['es', 'testApiKey', 'testEmail'])
-            ->addMethods(array('getVideoData'))
+            ->onlyMethods(array('getVideoData'))
             ->getMock();
 
         $kalturaMock->expects($this->once())

--- a/tests/PhpAllyTest.php
+++ b/tests/PhpAllyTest.php
@@ -14,12 +14,17 @@ class PhpAllyTest extends PhpAllyTestCase {
             'vimeoApiKey' => 'bef37736cfb26b6dc52986d8f531d0ad',
             'youtubeApiKey' => 'AIzaSyB5bTf8rbYwiM73k1rj8dDnwEalwTqdz_c'
         ];
-        $report = $ally->checkOne($this->getColorContrastHtml(), 'CidiLabs\\PhpAlly\\Rule\\CssTextStyleEmphasize', $options);
+        $report = $ally->checkOne($this->getColorEmphasisHtml(), 'CidiLabs\\PhpAlly\\Rule\\CssTextStyleEmphasize', $options);
         $issues = $report->getIssues();
         $errors = $report->getErrors();
         $issue = reset($issues);
 
-        $this->assertCount(1, $issues, 'Testcheckone should have 1 issues.');
+        if (!empty($errors)) {
+            print_r($errors);
+            exit;
+        }
+
+        $this->assertCount(1, $issues, 'TestCheckOne should have 1 issue.');
         $this->phpAllyIssueTest($issue);
         $this->phpAllyReportTest($report);
     }
@@ -37,7 +42,7 @@ class PhpAllyTest extends PhpAllyTestCase {
         $issues = $report->getIssues();
         $issue = reset($issues);
         
-        $this->assertCount(8, $issues, 'Total report should have 5 issues.');
+        $this->assertCount(6, $issues, 'Total report should have 5 issues.');
         $this->phpAllyIssueTest($issue);
         $this->phpAllyReportTest($report);
     }

--- a/tests/PhpAllyTestCase.php
+++ b/tests/PhpAllyTestCase.php
@@ -24,16 +24,14 @@ class PhpAllyTestCase extends TestCase {
             
             <p style="color: #0000FF";"><strong>Paragraph text does have enough contrast.</strong></p>
 
-            <p style="color: #000";">Paragraph text does not have enough contrast.</p>
-            <p style="color: #FFF";">Paragraph text does have enough contrast.</p>
-            <p style="color: #00A";">Paragraph text has blue text, no contrast.</p>
+            <p>Paragraph text <span style="color: #000">has</span> enough contrast.</p>
+            <p style="color: #FFF">Paragraph text NOT does have enough contrast.</p>
+            <p style="color: #00A">Paragraph text has blue text, no contrast.</p>
 
             <video controls width="250"src="/media/examples/friday.mp4">
-            <track default kind="captions"srclang="en"src="/media/examples/friday.vtt"/>
+            <track default kind="captions" srclang="en" src="/media/examples/friday.vtt"/>
             Sorry, your browser doesnt support embedded videos.
             </video>
-
-
         </div>';
     }
 
@@ -52,6 +50,11 @@ class PhpAllyTestCase extends TestCase {
     protected function getColorContrastHtml()
     {
         return '<div style="background-color: #444; background: no-repeat fixed center;"><p style="color: #000";">Paragraph text does not have enough contrast.</p><p style="color: #FFF";">Paragraph text does have enough contrast.</p><p style="color: #00A";">Paragraph text has blue text, no contrast.</p></div>';
+    }
+
+    protected function getColorEmphasisHtml()
+    {
+        return '<p>Text does not have <span style="color: red">correct emphasis</span>.</p>';
     }
 
     protected function getGoodBackgroundContrastColorNameHtml()

--- a/tests/VimeoTest.php
+++ b/tests/VimeoTest.php
@@ -20,7 +20,7 @@ class VimeoTest extends PhpAllyTestCase {
 
         $vimeoMock = $this->getMockBuilder(Vimeo::class)
              ->setConstructorArgs([$client, 'en', 'testApiKey'])
-             ->setMethods(array('getVideoData'))
+             ->onlyMethods(array('getVideoData'))
              ->getMock(); 
 
         $vimeoMock->expects($this->once())
@@ -42,7 +42,7 @@ class VimeoTest extends PhpAllyTestCase {
 
         $vimeoMock = $this->getMockBuilder(Vimeo::class)
              ->setConstructorArgs([$client, 'en', 'testApiKey'])
-             ->setMethods(array('getVideoData'))
+             ->onlyMethods(array('getVideoData'))
              ->getMock(); 
 
         $vimeoMock->expects($this->once())
@@ -64,7 +64,7 @@ class VimeoTest extends PhpAllyTestCase {
 
         $vimeoMock = $this->getMockBuilder(Vimeo::class)
              ->setConstructorArgs([$client, 'en', 'testApiKey'])
-             ->setMethods(array('getVideoData'))
+             ->onlyMethods(array('getVideoData'))
              ->getMock(); 
 
         $vimeoMock->expects($this->once())
@@ -86,7 +86,7 @@ class VimeoTest extends PhpAllyTestCase {
 
         $vimeoMock = $this->getMockBuilder(Vimeo::class)
              ->setConstructorArgs([$client, 'en', 'testApiKey'])
-             ->setMethods(array('getVideoData'))
+             ->onlyMethods(array('getVideoData'))
              ->getMock(); 
 
         $vimeoMock->expects($this->once())

--- a/tests/YoutubeTest.php
+++ b/tests/YoutubeTest.php
@@ -19,7 +19,7 @@ class YoutubeTest extends PhpAllyTestCase {
 
         $youtubeMock = $this->getMockBuilder(Youtube::class)
              ->setConstructorArgs([$client, 'en', 'testApiKey'])
-             ->setMethods(array('getVideoData'))
+             ->onlyMethods(array('getVideoData'))
              ->getMock(); 
 
         $youtubeMock->expects($this->once())
@@ -53,7 +53,7 @@ class YoutubeTest extends PhpAllyTestCase {
 
         $youtubeMock = $this->getMockBuilder(Youtube::class)
              ->setConstructorArgs([$client, 'en', 'testApiKey'])
-             ->setMethods(array('getVideoData'))
+             ->onlyMethods(array('getVideoData'))
              ->getMock(); 
 
         $youtubeMock->expects($this->once())
@@ -86,7 +86,7 @@ class YoutubeTest extends PhpAllyTestCase {
 
         $youtubeMock = $this->getMockBuilder(Youtube::class)
              ->setConstructorArgs([$client, 'en', 'testApiKey'])
-             ->setMethods(array('getVideoData'))
+             ->onlyMethods(array('getVideoData'))
              ->getMock(); 
 
         $youtubeMock->expects($this->once())
@@ -119,7 +119,7 @@ class YoutubeTest extends PhpAllyTestCase {
 
         $youtubeMock = $this->getMockBuilder(Youtube::class)
              ->setConstructorArgs([$client, 'en', 'testApiKey'])
-             ->setMethods(array('getVideoData'))
+             ->onlyMethods(array('getVideoData'))
              ->getMock(); 
 
         $youtubeMock->expects($this->once())
@@ -146,7 +146,7 @@ class YoutubeTest extends PhpAllyTestCase {
 
         $youtubeMock = $this->getMockBuilder(Youtube::class)
              ->setConstructorArgs([$client, 'en', 'testApiKey'])
-             ->setMethods(array('getVideoData'))
+             ->onlyMethods(array('getVideoData'))
              ->getMock(); 
 
         $youtubeMock->expects($this->once())
@@ -179,7 +179,7 @@ class YoutubeTest extends PhpAllyTestCase {
 
         $youtubeMock = $this->getMockBuilder(Youtube::class)
              ->setConstructorArgs([$client, 'en', 'testApiKey'])
-             ->setMethods(array('getVideoData'))
+             ->onlyMethods(array('getVideoData'))
              ->getMock(); 
 
         $youtubeMock->expects($this->once())


### PR DESCRIPTION
Also updates VimeoTest, YoutubeTest, and KalturaTest to use onlyMethods() instead of deprecated setMethods()