### PR TITLE
Fix imageHasAlt for dataDecorative true

### DIFF
--- a/src/Rule/ImageHasAlt.php
+++ b/src/Rule/ImageHasAlt.php
@@ -10,8 +10,8 @@ use DOMElement;
 */
 class ImageHasAlt extends BaseRule
 {
-    
-    
+
+
     public function id()
     {
         return self::class;
@@ -20,21 +20,14 @@ class ImageHasAlt extends BaseRule
     public function check()
     {
         foreach ($this->getAllElements('img') as $img) {
-			if (!$img->hasAttribute('alt')
-				|| $img->getAttribute('alt') == ''
-				|| $img->getAttribute('alt') == ' ') {
-				if(!($img->hasAttribute('role')
-					&& $img->getAttribute('role') == 'presentation')) {
-					$this->setIssue($img);
-				}
-
-                else if(!($img->hasAttribute('data-decorative')
-					&& $img->getAttribute('data-decorative') == 'true')) {
+			if (!$img->hasAttribute('alt') || trim($img->getAttribute('alt')) == '') {
+                if(!($img->hasAttribute('role') && $img->getAttribute('role') == 'presentation')
+                && !($img->hasAttribute('data-decorative') && $img->getAttribute('data-decorative') == 'true')) {
 					$this->setIssue($img);
 				}
 			}
         }
-        
+
         return count($this->issues);
     }
 

--- a/tests/ImageHasAltTest.php
+++ b/tests/ImageHasAltTest.php
@@ -42,4 +42,14 @@ class ImageHasAltTest extends PhpAllyTestCase {
 
         $this->assertEquals(1, $rule->check(), 'Image Has Alt should have one issue.');
     }
+
+    public function testCheckDataDecorativeTrue()
+    {
+        $html = '<div><img src="validDecorativeImage.png" data-decorative="true" role="none"></div>';
+        $dom = new \DOMDocument('1.0', 'utf-8');
+        $dom->loadHTML($html);
+        $rule = new ImageHasAlt($dom);
+
+        $this->assertEquals(0, $rule->check(), 'Image Has Alt should have no issues.');
+    }
 }


### PR DESCRIPTION
Fixes #12 

Images now only break the ImageHasAlt rule if they both do not have the presentation role and data-decorative isn't true. 

Added a test for when role is not presentation and data-decorative is true.