### PR TITLE
Removing rule looking for <noembed> tag. <noembed> is deprecated.

### DIFF
--- a/src/rules.json
+++ b/src/rules.json
@@ -9,7 +9,6 @@
   "CidiLabs\\PhpAlly\\Rule\\CssTextHasContrast",
   "CidiLabs\\PhpAlly\\Rule\\CssTextStyleEmphasize",
   "CidiLabs\\PhpAlly\\Rule\\DocumentReadingDirection",
-  "CidiLabs\\PhpAlly\\Rule\\EmbedHasAssociatedNoEmbed",
   "CidiLabs\\PhpAlly\\Rule\\FontIsNotUsed",
   "CidiLabs\\PhpAlly\\Rule\\HeadersHaveText",
   "CidiLabs\\PhpAlly\\Rule\\HeadingsInOrder",


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noembed