### PR TITLE
Video check log messages

### DIFF
--- a/src/Rule/VideoScan.php
+++ b/src/Rule/VideoScan.php
@@ -33,10 +33,8 @@ class VideoScan extends BaseRule
                 $url = $video->getAttribute($attr);
                 
                 // Get provider (Youtube, Vimeo, or Kaltura class)
-                $provider = $this->getVideoProvider($url);
-                
-                if (!isset($provider)) {
-                    $this->setError('Failed finding provider.');
+                $provider = $this->getVideoProvider($url);                
+                if (!$provider) {
                     continue;
                 }
 


### PR DESCRIPTION
This was creating error log messages for every link that wasn't a video. Fixed to just skip links that don't match the supported videos.