### PR TITLE
Revert "UDOIT3-535"

### DIFF
--- a/src/PhpAlly.php
+++ b/src/PhpAlly.php
@@ -5,9 +5,6 @@ namespace CidiLabs\PhpAlly;
 use DOMDocument;
 
 class PhpAlly {
-
-    global $linkArray = [];
-    
     public function __construct()
     {
 

--- a/src/Rule/BrokenLink.php
+++ b/src/Rule/BrokenLink.php
@@ -19,7 +19,7 @@ class BrokenLink extends BaseRule
 
 	public function check()
 	{
-		global $linkArray;
+		$linkArray = [];
 		foreach ($this->getAllElements('a') as $a) {
 			$href = $a->getAttribute('href');
 			if ($href) {

--- a/src/Rule/RedirectedLink.php
+++ b/src/Rule/RedirectedLink.php
@@ -19,7 +19,7 @@ class RedirectedLink extends BaseRule
 
 	public function check()
 	{
-		global $linkArray;
+		$linkArray = [];
 		foreach ($this->getAllElements('a') as $a) {
 			$href = $a->getAttribute('href');
 			if ($href) {


### PR DESCRIPTION
This reverts commit 99e162d912a5595d2dc060c5f7379cd4b1f9ea71.

I should have tested this more before merging in. This introduces a crash during the UDOIT scanning process. 