### PR TITLE
Add transparent background as a condition for CSS background color inheritance.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "cidilabs/phpally",
+    "name": "ucfopen/phpally",
     "type": "library",
     "description": "PHP Accessibility (a11y) Testing Library",
     "license": "MIT",

--- a/src/Rule/BaseRule.php
+++ b/src/Rule/BaseRule.php
@@ -130,16 +130,17 @@ class BaseRule implements PhpAllyRuleInterface {
 			$style = $this->walkUpTreeForInheritance($element, $style);
 		}
 
-		if($element->hasAttribute('style')) {
-			$inline_styles = explode(';', $element->getAttribute('style'));
-			foreach($inline_styles as $inline_style) {
-				$s = explode(':', $inline_style);
+		// if($element->hasAttribute('style')) {
+		// 	$inline_styles = explode(';', $element->getAttribute('style'));
+		// 	foreach($inline_styles as $inline_style) {
+		// 		$s = explode(':', $inline_style);
+				
+		// 		if(isset($s[1])){	// Edit:  Make sure the style attribute doesn't have a trailing ;
+		// 			$style[trim($s[0])] = trim(strtolower($s[1]));
+		// 		}
+		// 	}
+		// }
 
-				if(isset($s[1])){	// Edit:  Make sure the style attribute doesn't have a trailing ;
-					$style[trim($s[0])] = trim(strtolower($s[1]));
-				}
-			}
-		}
 		if($element->tagName === "strong"){
 			$style['font-weight'] = "bold";
 		}
@@ -201,7 +202,7 @@ class BaseRule implements PhpAllyRuleInterface {
 						$style[$k] = $v;
 					}
 
-					if((!isset($style['background-color'])) || strtolower($style['background-color']) == strtolower("#FFFFFF")){
+					if((!isset($style['background-color'])) || strtolower($style['background-color']) == strtolower("#FFFFFF") || strtolower($style['background-color']) == strtolower("transparent")){
 						if($k == 'background-color'){
 							$style['background-color'] = $v;
 						}

--- a/src/Rule/CssTextHasContrast.php
+++ b/src/Rule/CssTextHasContrast.php
@@ -189,6 +189,10 @@ class CssTextHasContrast extends BaseRule
 				$style = $this->getStyle($element);
 			}
 
+			if(strtolower($style['background-color']) == strtolower("transparent")) {
+				$style['background-color'] = $default_background;
+			}
+
 			// If the parent element doesn't have a text color, but one of the children does
 			// then we won't assume the parent is using the LMS default 
 			if (!isset($style['color']) && $this->childrenHaveTextColor($element)) {


### PR DESCRIPTION
Currently, whenever a user adds an HTML element to a page in Canvas with the `background-color: transparent` CSS style, PHPALLY flags that as a contrast issue when it sometimes isn't. This pull request fixes this issue by checking to see if the HTML element has the `background-color: transparent` style, and if so, it allows the element to inherit its parent element's background color.